### PR TITLE
[21812129 김태윤][버그식별 및 버그수정] 파일편집 기능의 파일생성 기능과  도움말의  불일치 수정

### DIFF
--- a/Control/FileEdit.py
+++ b/Control/FileEdit.py
@@ -22,7 +22,7 @@ def file_edit():
             print(" '종료'             입력시 프로그램을 종료할 수 있습니다.")
         elif select == "읽기":
             read_file()
-        elif select == "파일 생성 및 쓰기":
+        elif select == "파일생성":
             create_and_write_file()
         elif select == "찾아 바꾸기":
             modify_file()

--- a/main.py
+++ b/main.py
@@ -179,6 +179,7 @@ def print_system_info():
     """
     try:
         # 운영체제 및 기본 시스템 정보
+        print("===========내 시스템 정보==============")
         print(f"운영체제: {platform.system()}") 
         print(f"운영체제 상세 버전: {platform.version()}")  
         arch_info = platform.architecture()
@@ -186,6 +187,7 @@ def print_system_info():
         print(f"컴퓨터 이름: {platform.node()}")
         print(f"프로세서: {platform.processor()}")  
         print(f"Python 버전: {platform.python_version()}")
+        print("=======================================")
 
     except Exception as e:
         print(f"시스템 정보 출력 중 오류가 발생했습니다: {e}")
@@ -641,6 +643,9 @@ while not b_is_exit:
         print("중복 관리 기능 실행")
         Duplicates.duplicates()
 
+    elif func == "시스템정보확인":
+        print_system_info()
+
     elif func == "?":
         print("""
                 [도움말]
@@ -649,6 +654,7 @@ while not b_is_exit:
                 '파일관리' 입력시 파일을 관리할 수 있습니다.
                 '가독성'   입력시 파일의 단위를 읽기 좋게 볼 수 있습니다.
                 '중복관리' 입력시 중복 파일을 관리할 수 있습니다.
+                '시스템정보확인' 입력시 내 컴퓨터의 시스템 정보를 확인할 수 있습니다.
                 '종료'     입력시 프로그램을 종료합니다.
             """)
 


### PR DESCRIPTION
파일 편집 기능에서 '?' 입력시 

'읽기'
'파일생성'
'찾아 바꾸기'
'복사 및 붙여넣기'
'종료'

로 안내되어 출력되지만 실제로 '파일생성'을 입력하면 파일생성 기능이 동작하지 않습니다.
select문에는 '파일 생성 및 쓰기' 로 되어있기에 동작하지않음을 찾아내었습니다.
'파일 생성 및 쓰기' 는 사용자가 쓰기엔 다소 불편하므로 '파일생성'으로 일치시키기 위해
select문만 수정하였습니다.