### PR TITLE
[21812129 김태윤] 파일편집기능에서 파일생성 명령어 실행시 동작안하는 버그 수정

### DIFF
--- a/Control/FileEdit.py
+++ b/Control/FileEdit.py
@@ -22,7 +22,7 @@ def file_edit():
             print(" '종료'             입력시 프로그램을 종료할 수 있습니다.")
         elif select == "읽기":
             read_file()
-        elif select == "파일 생성 및 쓰기":
+        elif select == "파일생성":
             create_and_write_file()
         elif select == "찾아 바꾸기":
             modify_file()


### PR DESCRIPTION
if-elif 문에서 파일 생성 함수를 호출하기 위해 비교하는 select == 로직과 도움말출력함수에서 알려주는 '파일생성' 스트링이 달라서 호출이 안되는 버그를 select == "파일 생성 및 쓰기" 에서 select == "파일생성" 으로 수정하여 일치시킴으로써 버그를 수정하였습니다.