### PR TITLE
[22112133 서주형] 확장자 명에 따라서 생성하면 자동으로 분류하여 파일에 넣는 기능 추가

### DIFF
--- a/add_automatically_add.py
+++ b/add_automatically_add.py
@@ -1,0 +1,54 @@
+import os
+import shutil
+import time
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+class RuleBasedAutomationHandler(FileSystemEventHandler):
+    def __init__(self, rules):
+        self.rules = rules
+
+    def on_created(self, event):
+        self.process_event(event)
+
+    def on_modified(self, event):
+        self.process_event(event)
+
+    def process_event(self, event):
+        if event.is_directory:
+            return
+
+        for rule in self.rules:
+            if rule["condition"](event):
+                rule["action"](event)
+
+def monitor_directory(path, rules):
+    event_handler = RuleBasedAutomationHandler(rules)
+    observer = Observer()
+    observer.schedule(event_handler, path, recursive=True)
+    observer.start()
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+rules = [
+    {
+        "condition": lambda event: event.src_path.endswith(".txt"),
+        "action": lambda event: shutil.move(event.src_path, "/path/to/text_files")
+    },
+    {
+        "condition": lambda event: event.src_path.endswith((".jpg", ".png")),
+        "action": lambda event: shutil.copy(event.src_path, "/path/to/image_backups")
+    },
+]
+
+
+
+
+
+
+


### PR DESCRIPTION
어떤 파일을 생성할 때 확장자명에 따라서 파일들에 분류하여 넣는 기능입니다。
예를 들어 ｔｘｔ파일을 생성하면 텍스트파일만 따로 모아두는 폴더에 자동으로 넣어줍니다。