### PR TITLE
[22112133 서주형] 디렉토리의 최대 용량을 설정

### DIFF
--- a/add_restriction.py
+++ b/add_restriction.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+
+class LimitedDirectory:
+    def __init__(self, path, max_size_bytes):
+        self.path = path
+        self.max_size_bytes = max_size_bytes
+
+    def get_current_size(self):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(self.path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                total_size += os.path.getsize(fp)
+        return total_size
+
+    def add_file(self, file_path):
+        file_size = os.path.getsize(file_path)
+        if self.get_current_size() + file_size > self.max_size_bytes:
+            raise Exception(f"용량 제한 초과: {self.max_size_bytes} bytes")
+        shutil.copy2(file_path, self.path)
+
+    def remove_file(self, file_name):
+        file_path = os.path.join(self.path, file_name)
+        if os.path.exists(file_path):
+            os.remove(file_path)


### PR DESCRIPTION
디렉토리에 용량을 제한을 설정하여 파일이 추가/삭제 시에 최대 용량을 넘어가면 파일의 생성을 막거나 용량을 넘어섰다는 경고 문구를 출력하는 코드입니다. 