### PR TITLE
[22013816/이우용] 서브메뉴에서 종료시 메세지 불일치 수정

### DIFF
--- a/Control/AutoFileManage.py
+++ b/Control/AutoFileManage.py
@@ -67,7 +67,7 @@ def AutoFileManager():
             managerExecute()
 
         elif select == "종료":
-            print("자동 파일 관리자를 종료합니다.")
+            print("메인 메뉴로 이동합니다.")
             end = True
 
         else:

--- a/Control/Bookmark.py
+++ b/Control/Bookmark.py
@@ -26,7 +26,7 @@ def bookmark(bookmark : List):
             addFavorite(bookmark)
 
         elif select == "종료":
-            print("즐겨찾기를 종료합니다.")
+            print("메인 메뉴로 이동합니다.")
             finish = True
         
         else:

--- a/Control/Duplicates.py
+++ b/Control/Duplicates.py
@@ -23,7 +23,7 @@ def duplicates():
             remove_duplicates()
 
         elif select == "종료":
-            print("중복 관리를 종료합니다.")
+            print("메인 메뉴로 이동합니다.")
             finish = True
 
         else:

--- a/Control/FileControl.py
+++ b/Control/FileControl.py
@@ -61,7 +61,7 @@ def file_control():
             cut_file()
 
         elif select == "종료":
-            print("중복 관리를 종료합니다.")
+            print("메인 메뉴로 이동합니다.")
             finish = True
 
         else:

--- a/Control/FileEdit.py
+++ b/Control/FileEdit.py
@@ -29,7 +29,7 @@ def file_edit():
         elif select == "복사 및 붙여넣기":
             copy_and_paste_text()
         elif select == '종료':
-            print('파일 편집 기능을 종료합니다.')
+            print("메인 메뉴로 이동합니다.")
             finish = True
         else:
             print("잘못된 입력입니다. 다시 입력해주세요.")

--- a/Control/Readable.py
+++ b/Control/Readable.py
@@ -27,7 +27,7 @@ def readable():
             display_file_sizes()
 
         elif select == "종료":
-            print("중복 관리를 종료합니다.")
+            print("메인 메뉴로 이동합니다.")
             finish = True
 
         else:


### PR DESCRIPTION
서브메뉴에서 종료 입력시 "중복 관리를 종료합니다"로만 출력되는 문제가 있었습니다.
이를 "메인 메뉴로 돌아갑니다"로 통일하여 해결합니다.