### PR TITLE
[22321620 류승현] Windows 운영체제에 따른 winreg 모듈 임포트 기능 수정

### DIFF
--- a/Control/FileControl.py
+++ b/Control/FileControl.py
@@ -9,9 +9,13 @@ from typing import List
 import hashlib
 from functools import lru_cache
 from pathlib import Path
-import winreg
-import ctypes
 
+# 운영 체제에 따른 분기 처리
+# 'winreg' 모듈은 Windows에서만 임포트되고, 다른 운영체제에서는 해당 모듈을 사용하지 않음
+import platform
+if platform.system() == 'Windows':
+    import winreg
+    import ctypes
 
 
 def file_control():


### PR DESCRIPTION
기존 코드에선 import winreg를 사용함으로써 타 운영체제에서 이 코드를 실행할 때 발생하는 문제를 해결하기 위해 플랫폼 시스템이 Windows가 아닌 운영체제의 기기에선 winreg 모듈이 임포트되지 않도록 수정 